### PR TITLE
Reduce garbage generation

### DIFF
--- a/simplify.js
+++ b/simplify.js
@@ -48,26 +48,31 @@ function getSqSegDist(p, p1, p2) {
 // rest of the code doesn't care about point format
 
 // basic distance-based simplification
-function simplifyRadialDist(points, sqTolerance) {
+function simplifyRadialDist(points, sqTolerance, outPoints) {
 
-    var prevPoint = points[0],
-        newPoints = [prevPoint],
+    outPoints = outPoints || [points[0]];
+
+    var j = 1,
+        prevPoint = points[0],
         point;
 
     for (var i = 1, len = points.length; i < len; i++) {
         point = points[i];
 
         if (getSqDist(point, prevPoint) > sqTolerance) {
-            newPoints.push(point);
+            outPoints[j++] = point;
             prevPoint = point;
         }
     }
 
     if (prevPoint !== point) {
-        newPoints.push(point);
+        outPoints[j++] = point;
     }
 
-    return newPoints;
+    outPoints.length = j;
+
+    return outPoints;
+
 }
 
 // simplification using optimized Douglas-Peucker algorithm with recursion elimination
@@ -133,7 +138,7 @@ function simplify(points, tolerance, highestQuality, outPoints) {
 
     var sqTolerance = tolerance !== undefined ? tolerance * tolerance : 1;
 
-    points = highestQuality ? points : simplifyRadialDist(points, sqTolerance);
+    points = highestQuality ? points : simplifyRadialDist(points, sqTolerance, outPoints);
     outPoints = simplifyDouglasPeucker(points, sqTolerance, outPoints);
 
     return outPoints;

--- a/simplify.js
+++ b/simplify.js
@@ -99,11 +99,13 @@ function simplifyDouglasPeucker(points, sqTolerance) {
 
         if (maxSqDist > sqTolerance) {
             markers[index] = 1;
-            stack.push(first, index, index, last);
+            stack.push(first, index);
+            first = index;
+        } else {
+            last = stack.pop();
+            first = stack.pop();
         }
 
-        last = stack.pop();
-        first = stack.pop();
     }
 
     for (i = 0; i < len; i++) {

--- a/simplify.js
+++ b/simplify.js
@@ -129,14 +129,14 @@ function simplifyDouglasPeucker(points, sqTolerance, outPoints) {
 }
 
 // both algorithms combined for awesome performance
-function simplify(points, tolerance, highestQuality) {
+function simplify(points, tolerance, highestQuality, outPoints) {
 
     var sqTolerance = tolerance !== undefined ? tolerance * tolerance : 1;
 
     points = highestQuality ? points : simplifyRadialDist(points, sqTolerance);
-    points = simplifyDouglasPeucker(points, sqTolerance);
+    outPoints = simplifyDouglasPeucker(points, sqTolerance, outPoints);
 
-    return points;
+    return outPoints;
 }
 
 // export as AMD module / Node module / browser variable

--- a/simplify.js
+++ b/simplify.js
@@ -71,7 +71,7 @@ function simplifyRadialDist(points, sqTolerance) {
 }
 
 // simplification using optimized Douglas-Peucker algorithm with recursion elimination
-function simplifyDouglasPeucker(points, sqTolerance) {
+function simplifyDouglasPeucker(points, sqTolerance, outPoints) {
 
     var len = points.length,
         MarkerArray = typeof Uint8Array !== 'undefined' ? Uint8Array : Array,
@@ -79,7 +79,6 @@ function simplifyDouglasPeucker(points, sqTolerance) {
         first = 0,
         last = len - 1,
         stack = [],
-        newPoints = [],
         i, maxSqDist, sqDist, index;
 
     markers[first] = markers[last] = 1;
@@ -108,13 +107,25 @@ function simplifyDouglasPeucker(points, sqTolerance) {
 
     }
 
-    for (i = 0; i < len; i++) {
-        if (markers[i]) {
-            newPoints.push(points[i]);
+    if (outPoints) {
+        var j = 0;
+        for (i = 0; i < len; i++) {
+            if (markers[i]) {
+                outPoints[j++] = points[i];
+            }
         }
+        outPoints.length = j;
+        return outPoints;
+    } else {
+        var newPoints = [];
+        for (i = 0; i < len; i++) {
+            if (markers[i]) {
+                newPoints.push(points[i]);
+            }
+        }
+        return newPoints;
     }
 
-    return newPoints;
 }
 
 // both algorithms combined for awesome performance

--- a/test.js
+++ b/test.js
@@ -67,5 +67,16 @@ describe('simplify', function () {
 		var highQualityResult = simplify(points, 5, true);
 		assert.notDeepEqual(result, highQualityResult);
 	});
+	it('should permit in-place simplification', function() {
+		var pointsClone = points.slice();
+		var result = simplify(pointsClone, 5, false, pointsClone);
+		assert.deepEqual(result, simplified);
+		assert.strictEqual(result, pointsClone);
+	});
+	it('should permit high quality in-place simplification', function() {
+		var pointsClone = points.slice();
+		var result = simplify(pointsClone, 5, true, pointsClone);
+		assert.deepEqual(result, simplifiedHighQuality);
+		assert.strictEqual(result, pointsClone);
+	});
 });
-

--- a/test.js
+++ b/test.js
@@ -38,6 +38,18 @@ var simplified = [
     {"x":866.36,"y":480.77}
 ];
 
+var simplifiedHighQuality = [
+    {"x":224.55,"y":250.15},{"x":267.76,"y":213.81},{"x":296.91,"y":155.64},{"x":330.33,"y":137.57},
+    {"x":409.52,"y":141.14},{"x":439.60,"y":119.74},{"x":486.51,"y":106.75},{"x":529.57,"y":127.86},
+    {"x":539.27,"y":147.24},{"x":617.74,"y":159.86},{"x":629.55,"y":194.60},{"x":671.55,"y":222.55},
+    {"x":727.81,"y":213.36},{"x":739.94,"y":204.77},{"x":769.98,"y":208.42},{"x":784.20,"y":218.16},
+    {"x":800.24,"y":214.62},{"x":820.77,"y":236.17},{"x":859.88,"y":255.49},{"x":865.21,"y":268.53},
+    {"x":857.95,"y":280.30},{"x":867.79,"y":306.17},{"x":858.29,"y":314.94},{"x":854.54,"y":335.40},
+    {"x":860.92,"y":343.00},{"x":849.84,"y":359.59},{"x":854.56,"y":365.53},{"x":844.09,"y":371.89},
+    {"x":839.57,"y":390.40},{"x":848.40,"y":407.55},{"x":839.51,"y":432.76},{"x":853.97,"y":471.15},
+    {"x":866.36,"y":480.77}
+];
+
 var simplify = require('./simplify'),
 	assert = require('assert');
 
@@ -45,6 +57,15 @@ describe('simplify', function () {
 	it('should simplify points correctly with the given tolerance', function () {
 		var result = simplify(points, 5);
 		assert.deepEqual(result, simplified);
+	});
+	it('should simplify points correctly with the given tolerance with high quality', function () {
+		var result = simplify(points, 5, true);
+		assert.deepEqual(result, simplifiedHighQuality);
+	});
+	it('should simplify differently with high quality', function() {
+		var result = simplify(points, 5);
+		var highQualityResult = simplify(points, 5, true);
+		assert.notDeepEqual(result, highQualityResult);
 	});
 });
 


### PR DESCRIPTION
This PR reduces garbage generation by allowing the user to specify an existing array in which the simplified points should be stored. Specifically:

* `simplify` is modified uses this internally in "low quality" mode, reducing the amount of garbage generated by one `Array`
* the existing array can be the same as the array of points, permitting in-place, destructive simplification and meaning that the only garbage generated is the discarded points
* the existing array could be a separate, spare array, meaning that no garbage is generated at all