### PR TITLE
fix for when points.length <= 1

### DIFF
--- a/simplify.js
+++ b/simplify.js
@@ -113,6 +113,10 @@ function simplifyDouglasPeucker(points, sqTolerance) {
 
 // both algorithms combined for awesome performance
 function simplify(points, tolerance, highestQuality) {
+   
+    if (points.length <= 1) {
+        return points;
+    }
 
     var sqTolerance = tolerance !== undefined ? tolerance * tolerance : 1;
 

--- a/test.js
+++ b/test.js
@@ -46,3 +46,15 @@ t('simplifies points correctly with the given tolerance', function (t) {
 	t.same(result, simplified);
     t.end();
 });
+
+t('just return the points if it has only one point', function(t){
+  var result = simplify([{x:1, y:2}]);
+  t.same(result, [{x:1, y:2}]);
+    t.end();
+});
+
+t('just return the points if it has no points', function(t){
+  var result = simplify([]);
+  t.same(result, []);
+    t.end();
+});


### PR DESCRIPTION
This PR fixes cases when there is no points or only one point.

``` javascript
simplify([]);
// expected: []
// given: [undefined]

simplify([{x:1,y:2}])
// expected: [{x:1, y:2}]
// given: [{x:1,y:2}, undefined]
```

// Thanks for awesome library!
