### PR TITLE
Numeric parameter quality (0..1) instead boolean highestQuality

### DIFF
--- a/simplify.js
+++ b/simplify.js
@@ -100,13 +100,19 @@ function simplifyDouglasPeucker(points, sqTolerance) {
 }
 
 // both algorithms combined for awesome performance
-function simplify(points, tolerance, highestQuality) {
+function simplify(points, tolerance, quality) {
 
     if (points.length <= 2) return points;
 
     var sqTolerance = tolerance !== undefined ? tolerance * tolerance : 1;
 
-    points = highestQuality ? points : simplifyRadialDist(points, sqTolerance);
+    quality = quality !== undefined ? +quality : 0;
+    quality = quality < 0 ? 0 : (quality > 1 ? 1 : quality);
+    if (quality < 1) {
+        var sqToleranceFactor = (1 - quality) * (1 - quality);
+        points = simplifyRadialDist(points, sqTolerance * sqToleranceFactor);
+    }
+
     points = simplifyDouglasPeucker(points, sqTolerance);
 
     return points;


### PR DESCRIPTION


Попробовал библиотеку, и возникло ощущение слишком большой разницы между вариантами highestQuality on/off. Хочется чего-то промежуточного.

Идея состоит в том, чтобы превратить качество из бинарного флага в плавно изменяемый параметр от 0 до 1. Максимальное качество это quality=1, максимальная скорость - quality=0.
Модификация заключается в умножении tolerance для функции simplifyRadialDist (только для неё, основной алгоритм не трогаем) на весовой коэффициент 1 - quality.
Подбором параметра можно получить качество, близкое к максимальному, при незначительной потере скорости.

Важно отметить, что обратная совместимость при этом не ломается. Если передать параметр true, он преобразуется в 1, а функция отработает совершенно эквивалентно своему предыдущему поведению. Аналогично и с false/0.
К минусам можно отнести то, что зависимость там нелинейная, и quality=0.5 не обязательно соответствует интуитивному ощущению середины между 0 и 1.
