### PR TITLE
Improve TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ interface Point {
 	y: number;
 }
 
-declare function simplify (points: Point[], tolerance?: number, highQuality?: boolean): Point[];
+declare function simplify<T extends Point>(points: T[], tolerance?: number, highQuality?: boolean): T[];
 declare namespace simplify {}
 
 export = simplify;


### PR DESCRIPTION
Since the library doesn't modify the points you pass into it in any way and returns an array of points you pass into it, the types should reflect that.

You don't need to pass in the generic argument when using it since TypeScript will infer the type from the arguments.

This is a QoL improvement that doesn't force you to cast back to your type after using the `simplify` function.