### PR TITLE
Add link to Postgres Port (using PL/Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Checkout the demo with docs: http://mourner.github.io/simplify-js/
  * C# (Portable): [imshz / simplify-net](https://github.com/imshz/simplify-net) (by Shees Ul-Hassan)
  * Swift: [malcommac / SwiftSimplify](https://github.com/malcommac/SwiftSimplify) (by Daniele Margutti)
  * Unreal Engine: [SINTEF-9012 / SimplifyUnreal](https://github.com/SINTEF-9012/SimplifyUnreal) (by Antoine Pultier)
+ * Postgres (using PL/Python): [shubhamjain / simplify-coordinates-sql](https://github.com/shubhamjain/simplify-coordinates-sql) (by Shubham Jain)


### PR DESCRIPTION
I needed to simplify coordinates in the Database itself rather that create a program to ingest rows and update them. I have created a Postgres function that allows you to do that. It utilizes the [python port](https://github.com/omarestrella/simplify.py) of the library.

The reason for doing it PL/Python was that it's incredibly hard to do complex procedural processing in SQL.