### PR TITLE
Add link to new Rust port

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Checkout the demo with docs: http://mourner.github.io/simplify-js/
  * Processing: [ekeneijeoma / simplify-processing](https://github.com/ekeneijeoma/simplify-processing) (by Ekene Ijeoma)
  * AS3: [fnicollet / simplify-as3](https://github.com/fnicollet/simplify-as3) (by Fabien Nicollet)
  * Rust: [calvinmetcalf / simplify-rs](https://github.com/calvinmetcalf/simplify-rs) (by Calvin Metcalf)
+ * Rust: [kade-robertson / simplify-polyline](https://github.com/kade-robertson/simplify-polyline) (by Kade Robertson)
  * Ruby: [odlp / simplify_rb](https://github.com/odlp/simplify_rb) (by Oliver Peate)
  * Go: [yrsh / simplify_go](https://github.com/yrsh/simplify-go) (by Anton Korotkikh)
  * C# (Portable): [imshz / simplify-net](https://github.com/imshz/simplify-net) (by Shees Ul-Hassan)


### PR DESCRIPTION
The previous Rust port looks to be written against an old version of Rust (probably 0.8 based on commits) and has not compiled for quite some time now. I made a new one against modern Rust and included tests and benchmarks.

I wasn't sure if it made sense to remove the old version as it no longer works but I suppose if anyone is using a < 2015 version of Rust it may still have use.